### PR TITLE
Fix walk length offset in role embeddings

### DIFF
--- a/rolewalk.py
+++ b/rolewalk.py
@@ -18,8 +18,8 @@ def compute_embedding(X, H, n, theta, walk_len=3, offset=0):
     dim = 2 * theta.shape[1]
     T = H.copy()
     for w in range(walk_len):
-        T @= H
         compute_iter(X, T.indptr, T.data, theta, n, w + offset*walk_len, dim)
+        T @= H
 
 
 class RoleWalk:


### PR DESCRIPTION
## Summary
- ensure `compute_embedding` includes the first random walk step

## Testing
- `python -m py_compile rolewalk.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_6890b34254f0832fa04a12dccee39b94