### PR TITLE
Add benchmarks comparing RoleWalk and GraphWave

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,51 @@
+# Benchmarks
+
+This directory provides a simple script to compare node role embeddings
+produced by [RoleWalk](../rolewalk.py) against embeddings from the
+GraphWave library.
+
+## Setup
+
+The script relies on a few scientific Python packages.  The easiest way
+to install them is with `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Required packages:
+
+- [`networkx`](https://networkx.org/)
+- [`numpy`](https://numpy.org/)
+- [`pandas`](https://pandas.pydata.org/)
+- [`scikit-learn`](https://scikit-learn.org/)
+- [`matplotlib`](https://matplotlib.org/) (for optional plots)
+- [`karateclub`](https://karateclub.readthedocs.io/) (provides the GraphWave implementation)
+
+## Usage
+
+Run the benchmark script to generate embeddings and compare performance
+on several graphs:
+
+```bash
+python compare_graphwave_rolewalk.py
+```
+
+This prints a summary table to the console and writes the results to
+`comparison.csv`.  Use the `--plot` flag to create bar plots comparing
+the methods:
+
+```bash
+python compare_graphwave_rolewalk.py --plot
+```
+
+The script currently evaluates the following graphs:
+
+- Barbell graph
+- Balanced tree
+- Wikipedia voting network (if available via `karateclub`)
+
+Graphs with known structural role labels are evaluated with a
+logistic‑regression classifier, reporting accuracy and macro‑F1 scores.
+Graphs without ground‑truth labels are evaluated using the silhouette
+score after K‑means clustering.

--- a/benchmarks/compare_graphwave_rolewalk.py
+++ b/benchmarks/compare_graphwave_rolewalk.py
@@ -1,0 +1,161 @@
+import argparse
+import warnings
+from typing import Tuple, Optional
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, f1_score, silhouette_score
+from sklearn.model_selection import train_test_split
+from sklearn.cluster import KMeans
+
+from rolewalk import RoleWalk
+
+try:
+    from karateclub.node_embedding.structural import GraphWave
+except ImportError:  # pragma: no cover
+    GraphWave = None  # type: ignore
+
+
+def generate_barbell_graph(m1: int = 10, m2: int = 5) -> Tuple[nx.Graph, np.ndarray]:
+    """Return a barbell graph and role labels.
+
+    Nodes on the path joining the two cliques are assigned label 1 while
+    nodes inside the cliques receive label 0.
+    """
+    G = nx.barbell_graph(m1, m2)
+    y = np.zeros(G.number_of_nodes(), dtype=int)
+    path_nodes = list(range(m1, m1 + m2))
+    y[path_nodes] = 1
+    return G, y
+
+
+def generate_tree_graph(r: int = 2, h: int = 3) -> Tuple[nx.Graph, np.ndarray]:
+    """Return a balanced tree and role labels based on node depth."""
+    G = nx.balanced_tree(r, h)
+    depth = nx.shortest_path_length(G, source=0)
+    labels = []
+    for v in G.nodes():
+        if depth[v] == 0:
+            labels.append(0)  # root
+        elif G.degree[v] == 1:
+            labels.append(2)  # leaves
+        else:
+            labels.append(1)  # internal nodes
+    return G, np.asarray(labels, dtype=int)
+
+
+def load_wikipedia_voting_graph() -> Tuple[Optional[nx.Graph], Optional[np.ndarray]]:
+    """Attempt to load the Wikipedia voting network using karateclub."""
+    try:
+        from karateclub.dataset import GraphReader
+    except Exception as err:  # pragma: no cover
+        warnings.warn(f"karateclub is required for the Wikipedia dataset: {err}")
+        return None, None
+
+    try:
+        reader = GraphReader("wiki-vote")
+        G = reader.get_graph()
+        return G, None
+    except Exception as err:  # pragma: no cover
+        warnings.warn(f"Unable to load Wikipedia voting graph: {err}")
+        return None, None
+
+
+def evaluate_classification(X: np.ndarray, y: np.ndarray) -> Tuple[float, float]:
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.5, stratify=y, random_state=0
+    )
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X_train, y_train)
+    pred = clf.predict(X_test)
+    acc = accuracy_score(y_test, pred)
+    f1 = f1_score(y_test, pred, average="macro")
+    return acc, f1
+
+
+def evaluate_clustering(X: np.ndarray, n_clusters: int = 4) -> float:
+    labels = KMeans(n_clusters, random_state=0).fit_predict(X)
+    return silhouette_score(X, labels)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare RoleWalk and GraphWave")
+    parser.add_argument(
+        "--output", default="comparison.csv", help="Where to store the CSV summary."
+    )
+    parser.add_argument(
+        "--plot", action="store_true", help="Generate a comparison bar plot."
+    )
+    args = parser.parse_args()
+
+    graphs = {
+        "barbell": generate_barbell_graph,
+        "tree": generate_tree_graph,
+        "wiki": load_wikipedia_voting_graph,
+    }
+
+    results = []
+    for name, loader in graphs.items():
+        G, labels = loader()
+        if G is None:
+            continue
+
+        rw = RoleWalk(walk_len=3, embedding_dim=16)
+        X_rw = rw.transform(G)
+        if GraphWave is not None:
+            gw = GraphWave()
+            gw.fit(G)
+            X_gw = gw.get_embedding()
+        else:  # pragma: no cover
+            warnings.warn("GraphWave is unavailable; skipping.")
+            X_gw = None
+
+        if labels is not None:
+            acc, f1 = evaluate_classification(X_rw, labels)
+            results.append(
+                {"graph": name, "method": "rolewalk", "accuracy": acc, "macro_f1": f1}
+            )
+            if X_gw is not None:
+                acc, f1 = evaluate_classification(X_gw, labels)
+                results.append(
+                    {
+                        "graph": name,
+                        "method": "graphwave",
+                        "accuracy": acc,
+                        "macro_f1": f1,
+                    }
+                )
+        else:
+            score = evaluate_clustering(X_rw)
+            results.append({"graph": name, "method": "rolewalk", "silhouette": score})
+            if X_gw is not None:
+                score = evaluate_clustering(X_gw)
+                results.append(
+                    {"graph": name, "method": "graphwave", "silhouette": score}
+                )
+
+    if not results:
+        print("No graphs were evaluated.")
+        return
+
+    df = pd.DataFrame(results)
+    df.to_csv(args.output, index=False)
+    print(df)
+
+    if args.plot and len(df.columns) > 3:
+        import matplotlib.pyplot as plt
+
+        metric_cols = [c for c in df.columns if c not in {"graph", "method"}]
+        for metric in metric_cols:
+            pivot = df.pivot(index="graph", columns="method", values=metric)
+            pivot.plot(kind="bar")
+            plt.ylabel(metric)
+            plt.tight_layout()
+            plt.savefig(f"comparison_{metric}.png")
+            plt.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,0 +1,6 @@
+networkx
+numpy
+pandas
+scikit-learn
+matplotlib
+karateclub


### PR DESCRIPTION
## Summary
- add benchmark script generating sample graphs and comparing RoleWalk with GraphWave embeddings, reporting classification or clustering metrics
- document benchmarking setup and usage instructions
- include dependency list for benchmarking

## Testing
- `python -m pip install -r benchmarks/requirements.txt` *(failed: Could not find a version that satisfies the requirement networkx)*
- `python benchmarks/compare_graphwave_rolewalk.py` *(failed: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_6890b8630050832fb89eef3d1d7860ef