### PR TITLE
Add retrieval metrics and role distance ranking

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,6 +51,8 @@ The script currently evaluates the following graphs:
 
 Graphs with known structural role labels are evaluated with a
 logistic‑regression classifier, reporting accuracy and macro‑F1 scores.
+In addition, nodes are ranked by structural similarity to compute
+retrieval metrics such as mean average precision (mAP).
 Graphs without ground‑truth labels are evaluated using the silhouette
 score after K‑means clustering.
 

--- a/benchmarks/compare_graphwave_rolewalk.py
+++ b/benchmarks/compare_graphwave_rolewalk.py
@@ -10,7 +10,7 @@ from sklearn.metrics import accuracy_score, f1_score, silhouette_score
 from sklearn.model_selection import train_test_split
 from sklearn.cluster import KMeans
 
-from rolewalk import RoleWalk
+from rolewalk import RoleWalk, mean_average_precision
 
 try:
     from karateclub.node_embedding.structural import GraphWave
@@ -185,17 +185,26 @@ def main():
 
         if labels is not None:
             acc, f1 = evaluate_classification(X_rw, labels)
+            m_ap = mean_average_precision(X_rw, labels)
             results.append(
-                {"graph": name, "method": "rolewalk", "accuracy": acc, "macro_f1": f1}
+                {
+                    "graph": name,
+                    "method": "rolewalk",
+                    "accuracy": acc,
+                    "macro_f1": f1,
+                    "map": m_ap,
+                }
             )
             if X_gw is not None:
                 acc, f1 = evaluate_classification(X_gw, labels)
+                m_ap = mean_average_precision(X_gw, labels)
                 results.append(
                     {
                         "graph": name,
                         "method": "graphwave",
                         "accuracy": acc,
                         "macro_f1": f1,
+                        "map": m_ap,
                     }
                 )
         else:

--- a/tests/test_rolewalk.py
+++ b/tests/test_rolewalk.py
@@ -1,7 +1,7 @@
 import numpy as np
 import networkx as nx
 
-from rolewalk import RoleWalk
+from rolewalk import RoleWalk, mean_average_precision, pairwise_role_distances
 
 
 def test_transform_shapes():
@@ -29,3 +29,17 @@ def test_fit_predict_returns_valid_role_count():
     labels = rw.fit_predict(G, min_n_roles=min_roles, max_n_roles=max_roles)
     n_roles = len(np.unique(labels))
     assert min_roles <= n_roles <= max_roles
+
+
+def test_pairwise_role_distances_and_map():
+    X = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [0.0, 3.0]])
+    labels = np.array([0, 0, 0, 1])
+
+    dists, ranking = pairwise_role_distances(X)
+    assert dists.shape == (4, 4)
+    assert ranking.shape == (4, 3)
+    # node 0 is closest to node 1
+    assert ranking[0, 0] == 1
+
+    m_ap = mean_average_precision(X, labels)
+    assert 0.7 < m_ap < 0.8  # expected value is 0.75


### PR DESCRIPTION
## Summary
- provide `pairwise_role_distances` and `mean_average_precision` helpers to rank nodes by structural role
- evaluate retrieval quality in benchmark script and add mAP metric to outputs and plots
- document new retrieval evaluation and test distance and mAP helpers

## Testing
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68920dcae3a4832faa70d0ac9938eb8a