### PR TITLE
Restore benchmark datasets and fix wiki loader

### DIFF
--- a/benchmarks/compare_graphwave_rolewalk.py
+++ b/benchmarks/compare_graphwave_rolewalk.py
@@ -14,6 +14,10 @@ from rolewalk import RoleWalk
 from datasets import (
     generate_barbell_graph,
     generate_tree_graph,
+    generate_ring_of_cliques,
+    generate_grid_graph,
+    generate_star_graph,
+    generate_house_graph,
     load_wikipedia_voting_graph,
 )
 

--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -33,17 +33,101 @@ def generate_tree_graph(r: int = 2, h: int = 3) -> Tuple[nx.Graph, np.ndarray]:
     return G, np.asarray(labels, dtype=int)
 
 
-def load_wikipedia_voting_graph() -> Tuple[Optional[nx.Graph], Optional[np.ndarray]]:
-    """Attempt to load the Wikipedia voting network using karateclub."""
-    try:
-        from karateclub.dataset import GraphReader
-    except Exception as err:  # pragma: no cover
-        warnings.warn(f"karateclub is required for the Wikipedia dataset: {err}")
-        return None, None
+def generate_ring_of_cliques(
+    n_cliques: int = 4, clique_size: int = 4
+) -> Tuple[nx.Graph, np.ndarray]:
+    """Return a ring of cliques graph and role labels.
 
-    try:
+    Nodes that bridge cliques receive label ``1`` while all other nodes are
+    labelled ``0``.
+    """
+
+    G = nx.ring_of_cliques(n_cliques, clique_size)
+    labels = np.zeros(G.number_of_nodes(), dtype=int)
+    # Bridge nodes have one extra edge connecting to the next clique.
+    for node, degree in G.degree():
+        if degree > clique_size - 1:
+            labels[node] = 1
+    return G, labels
+
+
+def generate_grid_graph(m: int = 5, n: int = 5) -> Tuple[nx.Graph, np.ndarray]:
+    """Return an ``m`` by ``n`` grid graph and role labels.
+
+    Labels correspond to corners (0), edge nodes (1) and inner nodes (2).
+    """
+
+    G = nx.grid_2d_graph(m, n)
+    mapping = {node: idx for idx, node in enumerate(G.nodes())}
+    G = nx.relabel_nodes(G, mapping)
+    labels = np.zeros(G.number_of_nodes(), dtype=int)
+    for (i, j), idx in mapping.items():
+        if (i in {0, m - 1}) and (j in {0, n - 1}):
+            labels[idx] = 0  # corners
+        elif i in {0, m - 1} or j in {0, n - 1}:
+            labels[idx] = 1  # edges
+        else:
+            labels[idx] = 2  # interior
+    return G, labels
+
+
+def generate_star_graph(n_leaves: int = 10) -> Tuple[nx.Graph, np.ndarray]:
+    """Return a star graph with role labels for center and leaves."""
+
+    G = nx.star_graph(n_leaves)
+    labels = np.ones(G.number_of_nodes(), dtype=int)
+    labels[0] = 0  # center node
+    return G, labels
+
+
+def generate_house_graph() -> Tuple[nx.Graph, np.ndarray]:
+    """Return a house graph and role labels.
+
+    The graph consists of a square with a triangle on top. Nodes at the base of
+    the roof (degree 3) are labelled ``1``, the roof apex is labelled ``2`` and
+    the remaining nodes (degree 2 on the square base) are labelled ``0``.
+    """
+
+    G = nx.house_graph()
+    degrees = dict(G.degree())
+    labels = np.zeros(G.number_of_nodes(), dtype=int)
+    for node, deg in degrees.items():
+        if deg == 3:
+            labels[node] = 1
+        elif all(degrees[n] == 3 for n in G.neighbors(node)):
+            labels[node] = 2
+    return G, labels
+
+
+def load_wikipedia_voting_graph() -> Tuple[Optional[nx.Graph], Optional[np.ndarray]]:
+    """Load the Wikipedia voting network.
+
+    Attempts to use ``karateclub`` if available. If ``karateclub`` is not
+    installed or fails to retrieve the data, the function falls back to
+    downloading the edge list from the SNAP repository. If all methods fail,
+    ``(None, None)`` is returned.
+    """
+
+    # First try to use karateclub if available
+    try:  # pragma: no cover - optional dependency
+        from karateclub.dataset import GraphReader
+
         reader = GraphReader("wiki-vote")
         G = reader.get_graph()
+        return G, None
+    except Exception:
+        pass
+
+    # Fallback: attempt to download from SNAP
+    url = "https://snap.stanford.edu/data/wiki-Vote.txt.gz"
+    try:  # pragma: no cover - network access
+        import gzip
+        import io
+        from urllib.request import urlopen
+
+        with urlopen(url) as resp:
+            data = gzip.decompress(resp.read()).decode("utf-8")
+        G = nx.parse_edgelist(io.StringIO(data), nodetype=int, create_using=nx.DiGraph())
         return G, None
     except Exception as err:  # pragma: no cover
         warnings.warn(f"Unable to load Wikipedia voting graph: {err}")

--- a/benchmarks/perturbation_robustness.py
+++ b/benchmarks/perturbation_robustness.py
@@ -20,6 +20,10 @@ except Exception:  # pragma: no cover
 from datasets import (
     generate_barbell_graph,
     generate_tree_graph,
+    generate_ring_of_cliques,
+    generate_grid_graph,
+    generate_star_graph,
+    generate_house_graph,
     load_wikipedia_voting_graph,
 )
 
@@ -211,6 +215,10 @@ def main():
     graphs = {
         "barbell": generate_barbell_graph,
         "tree": generate_tree_graph,
+        "ring_of_cliques": generate_ring_of_cliques,
+        "grid": generate_grid_graph,
+        "star": generate_star_graph,
+        "house": generate_house_graph,
         "wiki": load_wikipedia_voting_graph,
     }
 


### PR DESCRIPTION
## Summary
- add grid, ring-of-cliques, star, and house benchmark generators
- repair Wikipedia voting dataset loader with fallback download
- expose new datasets in comparison and robustness scripts

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_b_68922169d0b0832f8f1f5187585c0ffd